### PR TITLE
Minor improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Michael Mogenson <michael.mogenson@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-arduino-leonardo = { git = "https://github.com/Rahix/avr-hal" }
 avr-device = "0.2.2"
 embedded-hal = "0.2.4"
 nb = "1.0.0"
@@ -16,6 +15,7 @@ cc = "1.0.60"
 
 [dev-dependencies]
 panic-halt = "0.2.0"
+arduino-leonardo = { git = "https://github.com/Rahix/avr-hal" }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Michael Mogenson <michael.mogenson@gmail.com>"]
 edition = "2018"
 
+[features]
+default = ["rt"]
+rt = ["avr-device/rt"]
+
 [dependencies]
 avr-device = "0.2.2"
 embedded-hal = "0.2.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![feature(abi_avr_interrupt)]
 #![allow(dead_code)]
 
-use arduino_leonardo::atmega32u4::{PLL, USB_DEVICE};
+use avr_device::atmega32u4::{PLL, USB_DEVICE};
 
 extern "C" {
     /* general */


### PR DESCRIPTION
Hey, thanks again for making this lib!  Immeditately had to start hacking on it :D 

It's just two minor things:  The library itself doesn't actually need anything from the HAL so I made it depend just on `avr-device`.  The example still uses the HAL though.

The other thing was making ISR definitions optional:  In some cases, someone might want manual control over these so it should be possible to manually define them outside the crate.  I've added documentation on how this would be done.